### PR TITLE
Use https for decidim-department_admin gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "decidim-courses", path: "./decidim-courses"
 gem "decidim-resource_banks", path: "./decidim-resource_banks"
 gem "decidim-term_customizer", git: "https://github.com/CodiTramuntana/decidim-module-term_customizer.git"
 
-gem 'decidim-department_admin', git: "git@github.com:gencat/decidim-department-admin.git"
+gem 'decidim-department_admin', git: "https://github.com/gencat/decidim-department-admin.git"
 
 gem "bootsnap", "~> 1.3"
 gem "rails", "< 6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: git@github.com:gencat/decidim-department-admin.git
-  revision: d66839837163a8045c5c9f9c56fa9d6fe7d810c4
-  specs:
-    decidim-department_admin (0.0.16)
-      decidim-core (>= 0.21.0)
-
-GIT
   remote: https://github.com/CodiTramuntana/decidim-module-term_customizer.git
   revision: c4ed0ffa87bd9977c6b470aa815d5dc2ed9f88a5
   specs:
@@ -229,6 +222,13 @@ GIT
       sassc-rails (~> 2.1.2)
     decidim-verifications (0.23.1)
       decidim-core (= 0.23.1)
+
+GIT
+  remote: https://github.com/gencat/decidim-department-admin.git
+  revision: d66839837163a8045c5c9f9c56fa9d6fe7d810c4
+  specs:
+    decidim-department_admin (0.0.16)
+      decidim-core (>= 0.21.0)
 
 PATH
   remote: decidim-courses


### PR DESCRIPTION
Use https protocol to install the gem, so we don't need a ssh key to install the gems in containers or servers