### PR TITLE
Remove both initiatives and consultations modules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ ruby RUBY_VERSION
 DECIDIM_VERSION = { git: "https://github.com/decidim/decidim", branch: "release/0.23-stable" }.freeze
 
 gem "decidim", DECIDIM_VERSION
-gem "decidim-consultations", DECIDIM_VERSION
 gem "decidim-courses", path: "./decidim-courses"
-gem "decidim-initiatives", DECIDIM_VERSION
 gem "decidim-resource_banks", path: "./decidim-resource_banks"
 gem "decidim-term_customizer", git: "https://github.com/CodiTramuntana/decidim-module-term_customizer.git"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,10 +69,6 @@ GIT
       decidim-core (= 0.23.1)
       jquery-rails (~> 4.3)
       redcarpet (~> 3.4)
-    decidim-consultations (0.23.1)
-      decidim-admin (= 0.23.1)
-      decidim-comments (= 0.23.1)
-      decidim-core (= 0.23.1)
     decidim-core (0.23.1)
       active_link_to (~> 1.0)
       anchored (>= 1.1.0)
@@ -168,17 +164,6 @@ GIT
       wkhtmltopdf-binary (~> 0.12)
     decidim-generators (0.23.1)
       decidim-core (= 0.23.1)
-    decidim-initiatives (0.23.1)
-      decidim-admin (= 0.23.1)
-      decidim-comments (= 0.23.1)
-      decidim-core (= 0.23.1)
-      decidim-verifications (= 0.23.1)
-      kaminari (~> 1.2, >= 1.2.1)
-      origami (~> 2.1)
-      virtus-multiparams (~> 0.1)
-      wicked (~> 1.3)
-      wicked_pdf (~> 1.4)
-      wkhtmltopdf-binary (~> 0.12)
     decidim-meetings (0.23.1)
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.0.9)
@@ -357,7 +342,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    colorize (0.8.1)
     concurrent-ruby (1.1.7)
     crack (0.4.4)
     crass (1.0.6)
@@ -579,8 +563,6 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    origami (2.1.0)
-      colorize (~> 0.7)
     orm_adapter (0.5.0)
     paper_trail (10.3.1)
       activerecord (>= 4.2)
@@ -791,8 +773,6 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    virtus-multiparams (0.1.1)
-      virtus (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (3.7.0)
@@ -807,8 +787,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked (1.3.4)
-      railties (>= 3.0.7)
     wicked_pdf (1.4.0)
       activesupport
     wisper (2.0.1)
@@ -825,11 +803,9 @@ DEPENDENCIES
   byebug (~> 11.0)
   daemons
   decidim!
-  decidim-consultations!
   decidim-courses!
   decidim-department_admin!
   decidim-dev!
-  decidim-initiatives!
   decidim-resource_banks!
   decidim-term_customizer!
   delayed_job_active_record

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -5,7 +5,7 @@ Decidim.configure do |config|
   config.application_name = "My Application Name"
 
   # The email that will be used as sender in all emails from Decidim
-  config.mailer_sender = "change-me@domain.org"
+  config.mailer_sender = ENV["SMTP_USERNAME"]
 
   # Sets the list of available locales for the whole application.
   #


### PR DESCRIPTION
- Remove both initiatives and consultations modules as petitioned by the client.
- Change the default sender inside Decidim's initializer.