### PR TITLE
Fix meetings creation, available_slots validations and newsletters user selection

### DIFF
--- a/db/migrate/20210312074809_invalidate_all_sessions_for_deleted_users.decidim.rb
+++ b/db/migrate/20210312074809_invalidate_all_sessions_for_deleted_users.decidim.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# This migration comes from decidim (originally 20210302150803)
+
+class InvalidateAllSessionsForDeletedUsers < ActiveRecord::Migration[5.2]
+  def up
+    Decidim::User.reset_column_information
+
+    Decidim::User.where.not(deleted_at: nil).find_each(&:invalidate_all_sessions!)
+  end
+
+  def down; end
+end

--- a/db/migrate/20210312074810_add_salt_to_decidim_forms_questionnaires.decidim_forms.rb
+++ b/db/migrate/20210312074810_add_salt_to_decidim_forms_questionnaires.decidim_forms.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# This migration comes from decidim_forms (originally 20201110152921)
+
+class AddSaltToDecidimFormsQuestionnaires < ActiveRecord::Migration[5.2]
+  class Questionnaire < ApplicationRecord
+    self.table_name = :decidim_forms_questionnaires
+  end
+
+  def change
+    add_column :decidim_forms_questionnaires, :salt, :string
+
+    Questionnaire.find_each do |questionnaire|
+      questionnaire.salt = Decidim::Tokenizer.random_salt
+      questionnaire.save!
+    end
+  end
+end

--- a/db/migrate/20210312074811_add_salt_to_decidim_meetings.decidim_meetings.rb
+++ b/db/migrate/20210312074811_add_salt_to_decidim_meetings.decidim_meetings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_meetings (originally 20201111133246)
+
+class AddSaltToDecidimMeetings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_meetings_meetings, :salt, :string
+    # we leave old entries empty to maintain the old pad reference
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_210609) do
+ActiveRecord::Schema.define(version: 2021_03_12_074811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -876,6 +876,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_210609) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "salt"
     t.index ["questionnaire_for_type", "questionnaire_for_id"], name: "index_decidim_forms_questionnaires_questionnaire_for"
   end
 
@@ -1094,6 +1095,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_210609) do
     t.string "decidim_author_type"
     t.integer "decidim_user_group_id"
     t.integer "comments_count", default: 0, null: false
+    t.string "salt"
     t.index ["decidim_author_id", "decidim_author_type"], name: "index_decidim_meetings_meetings_on_author"
     t.index ["decidim_author_id"], name: "index_decidim_meetings_meetings_on_decidim_author_id"
     t.index ["decidim_component_id"], name: "index_decidim_meetings_meetings_on_decidim_component_id"

--- a/decidim-courses/app/forms/decidim/courses/admin/course_form.rb
+++ b/decidim-courses/app/forms/decidim/courses/admin/course_form.rb
@@ -25,7 +25,7 @@ module Decidim
         translatable_attribute :registration_terms, String
 
         attribute :registrations_enabled, Boolean
-        attribute :available_slots, Integer
+        attribute :available_slots, Integer, default: 0
         attribute :hashtag, String
         attribute :promoted, Boolean
         attribute :area_id, Integer
@@ -61,7 +61,7 @@ module Decidim
 
         validates :banner_image, passthru: { to: Decidim::Course }
         validates :hero_image, passthru: { to: Decidim::Course }
-        validate :available_slots_greater_than_or_equal_to_registrations_count, if: ->(form) { form.registrations_enabled? && form.available_slots.positive? }
+        validate :available_slots_greater_than_or_equal_to_registrations_count, if: ->(form) { form.registrations_enabled? && form.available_slots.try(:positive?) }
 
         alias organization current_organization
 

--- a/decidim-courses/app/models/decidim/course.rb
+++ b/decidim-courses/app/models/decidim/course.rb
@@ -80,6 +80,12 @@ module Decidim
       where(promoted: true)
     end
 
+    def closed?
+      return false if end_date.blank?
+
+      end_date < Date.current
+    end
+
     def attachment_context
       :admin
     end

--- a/decidim-courses/app/presenters/decidim/courses/course_presenter.rb
+++ b/decidim-courses/app/presenters/decidim/courses/course_presenter.rb
@@ -10,7 +10,7 @@ module Decidim
       delegate :url, to: :banner_image, prefix: true
 
       def hero_image_url
-        return unless course.hero_image.try(:file)
+        return if course.hero_image.file.blank?
 
         uri = URI(course.hero_image.file.file)
         return uri unless uri.scheme.nil?
@@ -19,7 +19,7 @@ module Decidim
       end
 
       def banner_image_url
-        return unless course.banner_image.file.present?
+        return if course.banner_image.file.blank?
 
         uri = URI(course.banner_image.file.file)
         return uri unless uri.scheme.nil?

--- a/decidim-courses/app/presenters/decidim/courses/course_presenter.rb
+++ b/decidim-courses/app/presenters/decidim/courses/course_presenter.rb
@@ -10,7 +10,7 @@ module Decidim
       delegate :url, to: :banner_image, prefix: true
 
       def hero_image_url
-        return unless course.hero_image.file
+        return unless course.hero_image.try(:file)
 
         uri = URI(course.hero_image.file.file)
         return uri unless uri.scheme.nil?
@@ -19,7 +19,7 @@ module Decidim
       end
 
       def banner_image_url
-        return unless course.banner_image.file
+        return unless course.banner_image.file.present?
 
         uri = URI(course.banner_image.file.file)
         return uri unless uri.scheme.nil?

--- a/decidim-courses/config/locales/ca.yml
+++ b/decidim-courses/config/locales/ca.yml
@@ -2,6 +2,11 @@
 ca:
   activemodel:
     attributes:
+      course_registration_type:
+        registrations_count: Places
+        title: Títol
+        weight: Pes
+        name: Tipus d'inscripció
       course:
         announcement: Avís
         area_id: Àrea

--- a/decidim-courses/config/locales/en.yml
+++ b/decidim-courses/config/locales/en.yml
@@ -2,6 +2,11 @@
 en:
   activemodel:
     attributes:
+      course_registration_type:
+        registrations_count: Registrations count
+        title: Title
+        weight: Weight
+        name: Registration type
       course:
         announcement: Announcement
         area_id: Area

--- a/decidim-courses/config/locales/es.yml
+++ b/decidim-courses/config/locales/es.yml
@@ -2,6 +2,11 @@
 es:
   activemodel:
     attributes:
+      course_registration_type:
+        registrations_count: Plazas
+        title: Título
+        weight: Peso
+        name: Tipo de inscripción
       course:
         announcement: Aviso
         area_id: Área

--- a/decidim-resource_banks/app/models/decidim/resource_bank.rb
+++ b/decidim-resource_banks/app/models/decidim/resource_bank.rb
@@ -58,6 +58,10 @@ module Decidim
       Arel::Nodes::InfixOperation.new("->>", parent.table[:title], Arel::Nodes.build_quoted(I18n.locale.to_s))
     end
 
+    def closed?
+      false
+    end
+
     # Scope to return only the promoted resource banks.
     #
     # Returns an ActiveRecord::Relation.

--- a/decidim-resource_banks/config/locales/ca.yml
+++ b/decidim-resource_banks/config/locales/ca.yml
@@ -123,7 +123,7 @@ ca:
         title: Recursos
       resource_banks:
         filters:
-          areas: Àreas
+          areas: Àrees
           scope: Àmbit
           search: Cerca
           select_an_area: Selecciona una Àrea


### PR DESCRIPTION
Changes:

- Implements `closed?` method for newsletters to works
- Fixes courses validation for `availabe_slots` to be empty
- Adds pending migrations to fix method `salt` missing for meetings creation
- Add pending i18n