### PR TITLE
Add pending translations for course_registration_invite

### DIFF
--- a/config/locales/ca-conferences.yml
+++ b/config/locales/ca-conferences.yml
@@ -35,6 +35,7 @@ ca:
       conference_registration_type:
         description: Descripció
         price: Preu
+        title: Títol
         weight: Pes
       conference_speaker:
         affiliation: Afiliació

--- a/config/locales/es-conferences.yml
+++ b/config/locales/es-conferences.yml
@@ -35,6 +35,7 @@ es:
       conference_registration_type:
         description: Descripción
         price: Precio
+        title: Título
         weight: Peso
       conference_speaker:
         affiliation: Afiliación

--- a/decidim-courses/config/locales/ca.yml
+++ b/decidim-courses/config/locales/ca.yml
@@ -40,6 +40,11 @@ ca:
         professorship: Professorat
         methodology: Metodologia
         show_statistics: Mostrar estadístiques
+      course_registration_invite:
+        email: Email
+        name: Nom
+        registration_type_id: Tipus de registre
+        user_id: Usuari
       course_user_role:
         email: Correu electrònic
         name: Nom

--- a/decidim-courses/config/locales/en.yml
+++ b/decidim-courses/config/locales/en.yml
@@ -40,6 +40,11 @@ en:
         professorship: Professorship
         methodology: Methodology
         show_statistics: Show statistics
+      course_registration_invite:
+        email: Email
+        name: Name
+        registration_type_id: Registration type
+        user_id: User
       course_user_role:
         email: Email
         name: Name

--- a/decidim-courses/config/locales/es.yml
+++ b/decidim-courses/config/locales/es.yml
@@ -40,6 +40,11 @@ es:
         professorship: Profesorado
         methodology: Metodología
         show_statistics: Mostrar estadísticas
+      course_registration_invite:
+        email: Email
+        name: Nombre
+        registration_type_id: Tipo de registro
+        user_id: Usuario
       course_user_role:
         email: Correo electrónico
         name: Nombre


### PR DESCRIPTION
The invite form for courses was untranslated. This PR adds the pending translations for the form fields.

It also adds a single pending translation for conference_registration_type.