### PR TITLE
Footer logo in mobile view

### DIFF
--- a/app/assets/stylesheets/general/_footer.scss
+++ b/app/assets/stylesheets/general/_footer.scss
@@ -62,7 +62,7 @@ section.footer__subhero.extended.subhero.home-section {
 
 .main-footer__badge {
   @include breakpoint(992 down) {
-    display: none;
+    margin-left: 0;
   }
 
   margin-top: 15px;
@@ -71,6 +71,10 @@ section.footer__subhero.extended.subhero.home-section {
 
 .main-footer {
   .medium-8.large-6.large-offset-3.column {
+    @include breakpoint(992 down) {
+      width: 100%;
+    }
+
     width: 58%;
   }
 }


### PR DESCRIPTION
Show footer logo in mobile view and center text.

![Captura de pantalla de 2021-05-18 10-09-40](https://user-images.githubusercontent.com/75725233/118615761-56564e80-b7c1-11eb-9806-91bd6f67c6ea.png)
