### PR TITLE
Update URL of Decidim modules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,9 @@ gem "decidim", DECIDIM_VERSION
 gem "decidim-conferences", DECIDIM_VERSION
 gem "decidim-courses", path: "./decidim-courses"
 gem "decidim-resource_banks", path: "./decidim-resource_banks"
-gem "decidim-term_customizer", git: "https://github.com/CodiTramuntana/decidim-module-term_customizer.git"
+gem "decidim-term_customizer", "~> 0.23.0", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "0.23-stable"
 
-gem "decidim-department_admin", "0.2.1", git: "https://github.com/gencat/decidim-department-admin.git", branch: "0.2-stable"
+gem "decidim-department_admin", "~> 0.2.1", git: "https://github.com/gencat/decidim-module-department_admin.git", branch: "0.2-stable"
 
 gem "bootsnap", "~> 1.3"
 gem "rails", "< 6"
@@ -29,7 +29,7 @@ gem "whenever"
 gem "wicked_pdf"
 
 group :development, :test do
-  gem "byebug", "~> 11.0", platform: :mri
+  gem "byebug", "~> 11.1", platform: :mri
   gem "decidim-dev", DECIDIM_VERSION
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,20 +206,21 @@ GIT
       decidim-core (= 0.23.6)
 
 GIT
-  remote: https://github.com/CodiTramuntana/decidim-module-term_customizer.git
-  revision: 03ba3bc60a8416a236ab7c1f84f91649ed46b9e8
-  specs:
-    decidim-term_customizer (0.18.0)
-      decidim-admin (>= 0.18.0)
-      decidim-core (>= 0.18.0)
-
-GIT
-  remote: https://github.com/gencat/decidim-department-admin.git
+  remote: https://github.com/gencat/decidim-module-department_admin.git
   revision: 7995b623162a25023b11cd3ac9dab578091caa45
   branch: 0.2-stable
   specs:
     decidim-department_admin (0.2.1)
       decidim-core (< 0.24)
+
+GIT
+  remote: https://github.com/mainio/decidim-module-term_customizer.git
+  revision: c3fdec9f863351cc2e236cb03e2ab57ff7380ed7
+  branch: 0.23-stable
+  specs:
+    decidim-term_customizer (0.23.0)
+      decidim-admin (~> 0.23.0)
+      decidim-core (~> 0.23.0)
 
 PATH
   remote: decidim-courses
@@ -415,7 +416,7 @@ GEM
     erubi (1.10.0)
     etherpad-lite (0.3.0)
       rest-client (>= 1.6)
-    execjs (2.8.1)
+    execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     factory_bot_rails (4.11.1)
@@ -831,15 +832,15 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (~> 1.3)
-  byebug (~> 11.0)
+  byebug (~> 11.1.3)
   daemons
   decidim!
   decidim-conferences!
   decidim-courses!
-  decidim-department_admin (= 0.2.1)!
+  decidim-department_admin (~> 0.2.1)!
   decidim-dev!
   decidim-resource_banks!
-  decidim-term_customizer!
+  decidim-term_customizer (~> 0.23.0)!
   deface
   delayed_job_active_record
   execjs (= 2.7.0)


### PR DESCRIPTION
This PR updates the URL of two Decidim modules:

- `term_customizer` now uses the main repo url instead of CodiTramuntana's fork.
- `department_admin` new URL after https://github.com/gencat/decidim-module-department_admin/pull/49